### PR TITLE
PHP 8.2 fix - static property declerations

### DIFF
--- a/src/SerwerSMS.php
+++ b/src/SerwerSMS.php
@@ -48,7 +48,7 @@ class SerwerSMS {
 
 	public $stats;
 
-	public $tamplates;
+	public $templates;
 
 	public $error;
 

--- a/src/SerwerSMS/Account.php
+++ b/src/SerwerSMS/Account.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Account {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Blacklist.php
+++ b/src/SerwerSMS/Blacklist.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Blacklist {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Contacts.php
+++ b/src/SerwerSMS/Contacts.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Contacts {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Error.php
+++ b/src/SerwerSMS/Error.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Error {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Files.php
+++ b/src/SerwerSMS/Files.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Files {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Groups.php
+++ b/src/SerwerSMS/Groups.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Groups {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Messages.php
+++ b/src/SerwerSMS/Messages.php
@@ -4,6 +4,11 @@ namespace SerwerSMS\SerwerSMS;
 
 class Messages {
 
+    /**
+     * @var mixed
+     */
+    private $master;
+
     public function __construct($master) {
         $this->master = $master;
     }

--- a/src/SerwerSMS/Payments.php
+++ b/src/SerwerSMS/Payments.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Payments {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Phones.php
+++ b/src/SerwerSMS/Phones.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Phones {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Premium.php
+++ b/src/SerwerSMS/Premium.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Premium {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Senders.php
+++ b/src/SerwerSMS/Senders.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Senders {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Stats.php
+++ b/src/SerwerSMS/Stats.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Stats {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Subaccounts.php
+++ b/src/SerwerSMS/Subaccounts.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Subaccounts {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 

--- a/src/SerwerSMS/Templates.php
+++ b/src/SerwerSMS/Templates.php
@@ -4,7 +4,12 @@ namespace SerwerSMS\SerwerSMS;
 
 class Templates {
 
-	public function __construct($master) {
+    /**
+     * @var mixed
+     */
+    private $master;
+
+    public function __construct($master) {
 		$this->master = $master;
 	}
 


### PR DESCRIPTION
Recently, in WodGuru, we changed PHP version to 8.2.
In this version, dynamic property declarations are deprecated.
This pull request changes all dynamic declarations to static and should not make any breaking changes to the code.